### PR TITLE
Provide injectable bean to get the authenticated user

### DIFF
--- a/auth-demo/src/main/java/com/vaadin/auth/demo/view/ProfileView.java
+++ b/auth-demo/src/main/java/com/vaadin/auth/demo/view/ProfileView.java
@@ -3,8 +3,7 @@ package com.vaadin.auth.demo.view;
 import javax.annotation.security.PermitAll;
 import javax.servlet.http.HttpServletRequest;
 
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import com.vaadin.auth.starter.VaadinAuthContext;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 
 import com.vaadin.flow.component.UI;
@@ -30,15 +29,8 @@ public class ProfileView extends VerticalLayout {
 
     private final EmailField emailField = new EmailField("E-mail");
 
-    public ProfileView() {
-        OidcUser user = (OidcUser) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal();
-
-        String fullName = user.getFullName();
-        String email = user.getEmail();
-        String picture = user.getPicture();
-
-        setSpacing(false);
+    public ProfileView(VaadinAuthContext context) {
+        var optionalUser = context.getAuthenticatedUser();
 
         avatar.setWidth("96px");
         avatar.setHeight("96px");
@@ -47,10 +39,18 @@ public class ProfileView extends VerticalLayout {
         nameField.setReadOnly(true);
         emailField.setReadOnly(true);
 
-        avatar.setName(fullName);
-        avatar.setImage(picture);
-        nameField.setValue(fullName);
-        emailField.setValue(email);
+        setSpacing(false);
+
+        optionalUser.ifPresent(user -> {
+            String fullName = user.getFullName();
+            String email = user.getEmail();
+            String picture = user.getPicture();
+
+            avatar.setName(fullName);
+            avatar.setImage(picture);
+            nameField.setValue(fullName);
+            emailField.setValue(email);
+        });
 
         add(avatar, nameField, emailField);
 

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
@@ -9,7 +9,7 @@ import java.util.Optional;
  * <p>
  * An instance of this interface is available for injection as bean in view and
  * layout classes.
- * 
+ *
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
@@ -1,0 +1,9 @@
+package com.vaadin.auth.starter;
+
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.util.Optional;
+
+public interface VaadinAuthContext {
+    Optional<OidcUser> getAuthenticatedUser();
+}

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
@@ -5,17 +5,23 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import java.util.Optional;
 
 /**
- * An interface to access the authentication context of the application
- *
+ * An interface to access the authentication context of the application.
+ * <p>
+ * An instance of this interface is available for injection as bean in view and
+ * layout classes.
+ * 
  * @author Vaadin Ltd
  * @since 1.0
  */
 public interface VaadinAuthContext {
+
     /**
-     * Gets the authenticated user on the application done by the SSO providers
+     * Gets an {@link Optional} with an instance of the current user if it has
+     * been authenticated by a OpenID Connect provider, or empty if the user is
+     * not authenticated or has been authenticated by other means.
      *
-     * @return an optional {@link OidcUser} object if the user is authenticated
-     *         or an optional {@code null} otherwise
+     * @return an {@link Optional} with the current OIDC authenticated user, or
+     *         empty if none available
      */
     Optional<OidcUser> getAuthenticatedUser();
 }

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
@@ -4,6 +4,18 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 import java.util.Optional;
 
+/**
+ * An interface to access the authentication context of the application
+ *
+ * @author Vaadin Ltd
+ * @since 1.0
+ */
 public interface VaadinAuthContext {
+    /**
+     * Gets the authenticated user on the application done by the SSO providers
+     *
+     * @return an optional {@link OidcUser} object if the user is authenticated
+     *         or an optional {@code null} otherwise
+     */
     Optional<OidcUser> getAuthenticatedUser();
 }

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContextImpl.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContextImpl.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 /**
  * Default implementation of the {@link VaadinAuthContext} interface.
  */
-
 public class VaadinAuthContextImpl implements VaadinAuthContext {
 
     @Override

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContextImpl.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContextImpl.java
@@ -1,0 +1,29 @@
+package com.vaadin.auth.starter;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.util.Optional;
+
+/**
+ * Default implementation of the {@link VaadinAuthContext} interface.
+ */
+
+public class VaadinAuthContextImpl implements VaadinAuthContext {
+
+    @Override
+    public Optional<OidcUser> getAuthenticatedUser() {
+        var authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        if (authentication == null) {
+            return Optional.empty();
+        }
+
+        if (!(authentication.getPrincipal() instanceof OidcUser)) {
+            return Optional.empty();
+        }
+
+        return Optional.of((OidcUser) authentication.getPrincipal());
+    }
+}

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthSecurityConfiguration.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthSecurityConfiguration.java
@@ -2,6 +2,7 @@ package com.vaadin.auth.starter;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -63,5 +64,10 @@ public class VaadinAuthSecurityConfiguration extends VaadinWebSecurity {
             // access a protected view without authorization
             viewAccessChecker.setLoginView(loginRoute);
         }
+    }
+
+    @Bean
+    public VaadinAuthContext getAuthenticationContext() {
+        return new VaadinAuthContextImpl();
     }
 }

--- a/auth-starter/src/test/java/com/vaadin/auth/starter/VaadinAuthContextTest.java
+++ b/auth-starter/src/test/java/com/vaadin/auth/starter/VaadinAuthContextTest.java
@@ -1,0 +1,46 @@
+package com.vaadin.auth.starter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for VaadinAuthContext
+ */
+public class VaadinAuthContextTest {
+
+    @Test
+    public void unauthenticatedContextReturnsEmptyOptional() {
+        var authentication = mock(AnonymousAuthenticationToken.class);
+        var securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        SecurityContextHolder.setContext(securityContext);
+        var authContext = new VaadinAuthContextImpl();
+
+        assertTrue(authContext.getAuthenticatedUser().isEmpty());
+    }
+
+    @Test
+    public void authenticatedContextReturnsUserPrincipal() {
+        var principal = mock(OidcUser.class);
+        var authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(principal);
+        var securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        SecurityContextHolder.setContext(securityContext);
+        var authContext = new VaadinAuthContextImpl();
+
+        var user = authContext.getAuthenticatedUser().get();
+        assertInstanceOf(OidcUser.class, user);
+    }
+}


### PR DESCRIPTION
## Description

Create a `VaadinAuthContext` bean that can be inject into views to access information about the authenticated user.

Missing:
- [x] Documentation
- [x] Tests

Fixes #14

## Type of change

- [ ] Bugfix
- [x] Feature
