### PR TITLE
Add Back-Channel logout support

### DIFF
--- a/auth-starter/pom.xml
+++ b/auth-starter/pom.xml
@@ -21,6 +21,10 @@
             <artifactId>vaadin-spring</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/BackChannelLogoutFilter.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/BackChannelLogoutFilter.java
@@ -1,0 +1,143 @@
+package com.vaadin.auth.starter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Component
+public class BackChannelLogoutFilter extends GenericFilterBean {
+
+    static final String REGISTRATION_ID_URI_VARIABLE_NAME = "registrationId";
+
+    private static final String LOG_MESSAGE = "Did not match request to %s";
+
+    /* Value defined by the specification */
+    private static final String TOKEN_PARAM_NAME = "logout_token";
+
+    /* Value defined by the specification */
+    private static final String SID_CLAIM = "sid";
+
+    private final SessionRegistry sessionRegistry;
+
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    private RequestMatcher requestMatcher = new AntPathRequestMatcher(
+            VaadinAuthProperties.DEFAULT_BACKCHANNEL_LOGOUT_ROUTE);
+
+    public BackChannelLogoutFilter(SessionRegistry sessionRegistry,
+            ClientRegistrationRepository clientRegistrationRepository) {
+        this.sessionRegistry = sessionRegistry;
+        this.clientRegistrationRepository = clientRegistrationRepository;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+        final var httpRequest = (HttpServletRequest) request;
+        final var httpResponse = (HttpServletResponse) response;
+
+        if (requiresLogout(httpRequest, httpResponse)) {
+            performLogout(httpRequest, httpResponse);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    private void performLogout(HttpServletRequest request,
+            HttpServletResponse response) throws IOException, ServletException {
+
+        logger.debug("Matching Back-Channel logout request");
+
+        final var clientRegistrationId = requestMatcher.matcher(request)
+                .getVariables().get(REGISTRATION_ID_URI_VARIABLE_NAME);
+
+        if (clientRegistrationId == null) {
+            logger.warn("Back-Channel logout request matcher missing "
+                    + "required registrationId URI variable:"
+                    + REGISTRATION_ID_URI_VARIABLE_NAME);
+            // Set the response status to 400 Bad Request as per specification
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        final var issuerUri = clientRegistrationRepository
+                .findByRegistrationId(clientRegistrationId).getProviderDetails()
+                .getIssuerUri();
+        final var decoder = JwtDecoders.fromOidcIssuerLocation(issuerUri);
+        final var token = request.getParameter(TOKEN_PARAM_NAME);
+
+        if (token == null) {
+            logger.warn("Back-Channel logout request missing parameter: "
+                    + TOKEN_PARAM_NAME);
+            // Set the response status to 400 Bad Request as per specification
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // TODO: Token MUST be validated as described in
+        // "2.6. Logout Token Validation"
+        // https://openid.net/specs/openid-connect-backchannel-1_0.html
+        final var jwt = decoder.decode(token);
+
+        logger.debug("JWT claims: " + jwt.getClaims());
+
+        final var sid = jwt.getClaimAsString(SID_CLAIM);
+
+        sessionRegistry.getAllPrincipals().stream().filter(principal -> {
+            if (principal instanceof OidcUser) {
+                final var user = (OidcUser) principal;
+                return sid.equals(user.getClaimAsString(SID_CLAIM));
+            } else {
+                return false;
+            }
+        }).flatMap(p -> sessionRegistry.getAllSessions(p, false).stream()).peek(
+                session -> logger.debug("Matching session set to expire now: "
+                        + session.getSessionId()))
+                .forEach(SessionInformation::expireNow);
+
+        // Set the response status to 200 OK as per specification
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    private boolean requiresLogout(HttpServletRequest request,
+            HttpServletResponse response) {
+        if (requestMatcher.matches(request)) {
+            return true;
+        }
+        if (logger.isTraceEnabled()) {
+            logger.trace(LogMessage.format(LOG_MESSAGE, this.requestMatcher));
+        }
+        return false;
+    }
+
+    public RequestMatcher getRequestMatcher() {
+        return requestMatcher;
+    }
+
+    public void setRequestMatcher(RequestMatcher logoutRequestMatcher) {
+        Assert.notNull(logoutRequestMatcher,
+                "logoutRequestMatcher cannot be null");
+        requestMatcher = logoutRequestMatcher;
+    }
+
+    public void setBackChannelLogoutRoute(String backchannelLogoutRoute) {
+        setRequestMatcher(new AntPathRequestMatcher(backchannelLogoutRoute));
+    }
+}

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthContext.java
@@ -2,8 +2,6 @@ package com.vaadin.auth.starter;
 
 import java.util.Optional;
 
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-
 /**
  * An interface to access the authentication context of the application.
  * <p>
@@ -23,7 +21,7 @@ public interface VaadinAuthContext {
      * @return an {@link Optional} with the current OIDC authenticated user, or
      *         empty if none available
      */
-    Optional<OidcUser> getAuthenticatedUser();
+    Optional<VaadinUser> getAuthenticatedUser();
 
     /**
      * Initiates the logout process of the current OIDC authenticated user by

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthDefaultBeans.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthDefaultBeans.java
@@ -1,0 +1,17 @@
+package com.vaadin.auth.starter;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.session.SessionRegistryImpl;
+
+@Configuration
+public class VaadinAuthDefaultBeans {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SessionRegistry getSessionRegistry() {
+        return new SessionRegistryImpl();
+    }
+}

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthProperties.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinAuthProperties.java
@@ -27,6 +27,23 @@ public class VaadinAuthProperties {
     static final String DEFAULT_LOGOUT_REDIRECT_ROUTE = "/";
 
     /**
+     * The default Back-Channel Logout route. This should be the same as in the
+     * OIDC provider's configuration to be able to accept logout notices as
+     * described by the specification. It requires a URI variable to match the
+     * client registration-id: {@code registrationId}.
+     *
+     * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
+     */
+    static final String DEFAULT_BACKCHANNEL_LOGOUT_ROUTE = "/logout/back-channel/{"
+            + BackChannelLogoutFilter.REGISTRATION_ID_URI_VARIABLE_NAME + "}";
+
+    /**
+     * The default maximum number of concurrent sessions allowed per user: -1
+     * means any number of concurrent sessions is allowed.
+     */
+    static final int DEFAULT_MAXIMUM_SESSIONS_PER_USER = -1;
+
+    /**
      * Enables (or disables) auto-configuration.
      */
     private boolean autoConfigure = true;
@@ -40,6 +57,23 @@ public class VaadinAuthProperties {
      * The route to redirect to after successful logout.
      */
     private String logoutRedirectRoute = DEFAULT_LOGOUT_REDIRECT_ROUTE;
+
+    /**
+     * If set to {@code true} it enables support for Back-Channel logout.
+     */
+    private boolean backChannelLogout = false;
+
+    /**
+     * The route to match Back-Channel logout requests against. The default
+     * value is {@code /backchannel-logout}.
+     */
+    private String backChannelLogoutRoute = DEFAULT_BACKCHANNEL_LOGOUT_ROUTE;
+
+    /**
+     * The number of maximum concurrent sessions allowed per user. The default
+     * value is -1 which means any number of concurrent sessions is allowed.
+     */
+    private int maximumConcurrentSessions = DEFAULT_MAXIMUM_SESSIONS_PER_USER;
 
     /**
      * Checks is auto-configuration of {@link VaadinAuthSecurityConfiguration}
@@ -99,5 +133,63 @@ public class VaadinAuthProperties {
      */
     public void setLogoutRedirectRoute(String logoutRedirectRoute) {
         this.logoutRedirectRoute = logoutRedirectRoute;
+    }
+
+    /**
+     * Checks weather Back-Channel logout is enabled.
+     *
+     * @return {@code true} if Back-Channel logout is enabled, {@code false}
+     *         otherwise
+     */
+    public boolean isBackChannelLogout() {
+        return backChannelLogout;
+    }
+
+    /**
+     * Sets is Back-Channel logout is enabled.
+     *
+     * @param backChannelLogout
+     *            weather to enable or disable Back-Channel logout
+     */
+    public void setBackChannelLogout(boolean backChannelLogout) {
+        this.backChannelLogout = backChannelLogout;
+    }
+
+    /**
+     * Gets the Back-Channel Logout route.
+     *
+     * @return the Back-Channel Logout route
+     */
+    public String getBackChannelLogoutRoute() {
+        return backChannelLogoutRoute;
+    }
+
+    /**
+     * Sets the Back-Channel Logout route.
+     *
+     * @param backchannelLogoutRoute
+     *            the Back-Channel Logout route
+     */
+    public void setBackChannelLogoutRoute(String backchannelLogoutRoute) {
+        this.backChannelLogoutRoute = backchannelLogoutRoute;
+    }
+
+    /**
+     * Gets the maximum number of concurrent sessions per user.
+     *
+     * @return the maximum number of concurrent sessions
+     */
+    public int getMaximumConcurrentSessions() {
+        return maximumConcurrentSessions;
+    }
+
+    /**
+     * Sets maximum number of concurrent sessions per user.
+     *
+     * @param maximumConcurrentSessions
+     *            maximum number of concurrent sessions
+     */
+    public void setMaximumConcurrentSessions(int maximumConcurrentSessions) {
+        this.maximumConcurrentSessions = maximumConcurrentSessions;
     }
 }

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinUser.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinUser.java
@@ -1,0 +1,11 @@
+package com.vaadin.auth.starter;
+
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+public class VaadinUser extends DefaultOidcUser {
+
+    VaadinUser(OidcUser oidcUser) {
+        super(oidcUser.getAuthorities(), oidcUser.getIdToken());
+    }
+}

--- a/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinUserService.java
+++ b/auth-starter/src/main/java/com/vaadin/auth/starter/VaadinUserService.java
@@ -1,0 +1,15 @@
+package com.vaadin.auth.starter;
+
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+public class VaadinUserService extends OidcUserService {
+
+    @Override
+    public VaadinUser loadUser(OidcUserRequest userRequest)
+            throws OAuth2AuthenticationException {
+        final var oidcUser = super.loadUser(userRequest);
+        return new VaadinUser(oidcUser);
+    }
+}

--- a/auth-starter/src/main/resources/META-INF/spring.factories
+++ b/auth-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.vaadin.auth.starter.VaadinAuthDefaultBeans,\
 com.vaadin.auth.starter.VaadinAuthSecurityConfiguration


### PR DESCRIPTION
This adds Back-Channel logout support as discussed in #29 

- It enables Spring's session-concurrency and provides a `SessionRegistry` bean.
- It adds a `BackChannelLogoutFilter` to filter back-channel logout requests from the OIDC provider, decodes the JWT and extracts the SID-claim comparing it against principals with active sessions in the registry, expiring matching ones.
- It handles session expiration exceptions for both plain and XHR (UIDL) requests.

Still needs:
- [ ] JavaDoc
- [ ] Tests